### PR TITLE
backported support for embedding screenshots in report from gulp-protractor-cucumber-html-report

### DIFF
--- a/lib/html_formatter.js
+++ b/lib/html_formatter.js
@@ -32,6 +32,43 @@ module.exports = (function () {
         });
     }
 
+    /**
+     * Checks if the step is an empty After step
+     * @param step - object which contains step data
+     * @returns boolean
+     */
+    function isEmptyAfterStep(step) {
+        return step.keyword.trim() === 'After' && step.name === undefined && step.embeddings === undefined;
+    }
+
+    /**
+     * Checks if the step is an After step containing a screenshot
+     * @param step - object which contains step data
+     * @returns boolean
+     */
+    function isAfterStepWithScreenshot(step) {
+        return step.keyword.trim() === 'After'
+            && step.embeddings
+            && step.embeddings[0]
+            && step.embeddings[0].mime_type === 'image/png';
+    }
+
+    /**
+     * Return html code of step element based on step template
+     * @param step - object which contains step data
+     * @returns string
+     */
+    function getAfterScreenshotStep(step) {
+        var template = grunt.file.read(templates.screenshotTemplate),
+            stepTemplate;
+
+        stepTemplate = grunt.template.process(template, {
+            data: {
+                screenshot: step.embeddings && step.embeddings[0] ? step.embeddings[0].data : ''
+            }
+        });
+        return stepTemplate;
+    }
 
     /**
      * Return html code of step element based on step template
@@ -152,6 +189,7 @@ module.exports = (function () {
             });
         return header;
     }
+
     function getCurrentDate() {
         function leadingZero(i) {
             return (i < 10) ? '0' + i : i;
@@ -207,14 +245,24 @@ module.exports = (function () {
                         isPassed = true;
                         for (var k = 0; k < testResults[i].elements[j].steps.length; k++) {
                             step = testResults[i].elements[j].steps[k];
-                            stepsHtml += getStep(step);
-                            stepsNumber++;
-                            stepsNumberInFeature++;
-                            if (step.result.status !== statuses.PASSED) {
-                                isPassed = false;
-                            } else if (step.result.status === statuses.PASSED) {
-                                passedSteps++;
-                                passedStepsInFeature++;
+
+                            if (isEmptyAfterStep(step)) {
+                                continue;
+                            }
+
+                            if (isAfterStepWithScreenshot(step)) {
+                                stepsHtml += getAfterScreenshotStep(step);
+
+                            } else {
+                                stepsHtml += getStep(step);
+                                stepsNumber++;
+                                stepsNumberInFeature++;
+                                if (step.result.status !== statuses.PASSED) {
+                                    isPassed = false;
+                                } else if (step.result.status === statuses.PASSED) {
+                                    passedSteps++;
+                                    passedStepsInFeature++;
+                                }
                             }
                         }
 

--- a/tasks/protractor-cucumber-html-report.js
+++ b/tasks/protractor-cucumber-html-report.js
@@ -29,7 +29,8 @@ module.exports = function(grunt) {
         scenarioTemplate: currentDir + '/../templates/scenario_template.html',
         stepTemplate: currentDir + '/../templates/step_template.html',
         scenarioContainerTemplate: currentDir + '/../templates/scenario-container_template.html',
-        featureContainerTemplate: currentDir + '/../templates/feature-container_template.html'
+        featureContainerTemplate: currentDir + '/../templates/feature-container_template.html',
+        screenshotTemplate: currentDir + '/../templates/screenshot_template.html'
       }
     }),
       EXAMPLE_TEST_RESULT_PATH = currentDir + '/../assets/example_test_result.json',

--- a/templates/screenshot_template.html
+++ b/templates/screenshot_template.html
@@ -1,0 +1,5 @@
+<div class="step">
+    <% if (screenshot) { %>
+        <img src="data:image/png;base64,<%= screenshot %>" width="1050" />
+    <% } %>
+</div>


### PR DESCRIPTION
when adding screenshots to the cucumber report by means of:

```
this.After(function (scenario, callback) {
        if(scenario.isFailed()){
                   browser.takeScreenshot().then(function (buffer) {
                       scenario.attach(new Buffer(buffer, 'base64').toString('binary'), 'image/png');
                       browser.quit().then(function () {
                           callback();
                       });
                   });
               }
        else
        callback()
    });
```

these screenshots are now included in the html report
