### PR TITLE
Ignore empty Before steps, copied from @danyc on the gulp project

### DIFF
--- a/lib/html_formatter.js
+++ b/lib/html_formatter.js
@@ -33,6 +33,15 @@ module.exports = (function () {
     }
 
     /**
+     * Checks if the step is an empty Before step
+     * @param step - object which contains step data
+     * @returns boolean
+     */
+    function isEmptyBeforeStep(step) {
+        return step.keyword.trim() === 'Before' && step.name === undefined && step.embeddings === undefined;
+    }
+
+    /**
      * Checks if the step is an empty After step
      * @param step - object which contains step data
      * @returns boolean
@@ -82,7 +91,7 @@ module.exports = (function () {
                 errorDetails: step.result ? toHtmlEntities(step.result.error_message) : '',
                 duration: step.result.duration ? calculateDuration(step.result.duration) : 'no data',
                 tableOutline: step.rows,
-                name: step.keyword + step.name
+                name: step.keyword + (step.name ? step.name : '')
             }
         });
         return stepTemplate;
@@ -246,7 +255,7 @@ module.exports = (function () {
                         for (var k = 0; k < testResults[i].elements[j].steps.length; k++) {
                             step = testResults[i].elements[j].steps[k];
 
-                            if (isEmptyAfterStep(step)) {
+                            if (isEmptyAfterStep(step) || isEmptyBeforeStep(step)) {
                                 continue;
                             }
 


### PR DESCRIPTION
Currently empty Before steps are included in the report as undefined so this change should ignore it:
Code copied from: https://github.com/mrooding/gulp-protractor-cucumber-html-report/commit/71a5f32b2e49bf3c6bbf3f7ec49b7619ce978af7
